### PR TITLE
feat #PB-1644 Copy button

### DIFF
--- a/.storybook/stories/Buttons/Button.stories.tsx
+++ b/.storybook/stories/Buttons/Button.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { Button } from '../../src/buttons'
-import { LinePlus } from '../../src/icons'
-import { iconOptionsWithNull } from '../../utils/argTypesOptions/icon'
+import { Button } from '../../../src/buttons'
+import { LinePlus } from '../../../src/icons'
+import { iconOptionsWithNull } from '../../../utils/argTypesOptions/icon'
 
 const meta: Meta<typeof Button> = {
   title: 'Buttons/Button',

--- a/.storybook/stories/Buttons/CopyButton.stories.tsx
+++ b/.storybook/stories/Buttons/CopyButton.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { CopyButton } from '../../../src/buttons'
+
+const meta: Meta<typeof CopyButton> = {
+  title: 'Buttons/CopyButton',
+  component: CopyButton,
+}
+
+export default meta
+type Story = StoryObj<typeof CopyButton>
+
+export const Overview = {
+  args: { value: 'https://www.google.com', copyable: true },
+}

--- a/.storybook/stories/Buttons/IconButton.stories.tsx
+++ b/.storybook/stories/Buttons/IconButton.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { IconButton } from '../../src/buttons'
-import { LineMenu2 } from '../../src/icons'
-import { iconOptions } from '../../utils/argTypesOptions/icon'
+import { IconButton } from '../../../src/buttons'
+import { LineMenu2 } from '../../../src/icons'
+import { iconOptions } from '../../../utils/argTypesOptions/icon'
 
 const meta: Meta<typeof IconButton> = {
   title: 'Buttons/IconButton',

--- a/.storybook/stories/Texts/Text.stories.tsx
+++ b/.storybook/stories/Texts/Text.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { Text } from '../../src/texts'
+import { Text } from '../../../src/texts'
 
 const meta: Meta<typeof Text> = {
   title: 'Texts/Text',

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "react-native": "^0.72.4",
     "react-native-gesture-handler": "^2.14.0",
     "react-native-svg": "^13.6.0",
-    "react-native-toast-message": "^2.1.5"
+    "react-native-toast-message": "^2.1.5",
+    "@react-native-clipboard/clipboard": "^1.11.1"
   },
   "devDependencies": {
     "react-native-select-dropdown": "^4.0.1",
@@ -85,7 +86,8 @@
     "storybook": "^8.4.7",
     "styled-components": "^6.1.14",
     "typescript": "^5.7.2",
-    "webpack": "^5.97.1"
+    "webpack": "^5.97.1",
+    "@react-native-clipboard/clipboard": "^1.11.1"
   },
   "scripts": {
     "build": "rimraf dist && tsc",

--- a/src/buttons/CopyButton/CopyButton.Types.tsx
+++ b/src/buttons/CopyButton/CopyButton.Types.tsx
@@ -1,0 +1,16 @@
+import { Theme } from '../../types/Theme'
+
+/**
+ * Button to copy a value
+ */
+export interface CopyButtonProps {
+  /**The value to copy */
+  value: string
+  /**If the button can copy the value */
+  copyable: boolean
+}
+
+export interface StyledTextProps {
+  disabled: boolean
+  theme: Theme
+}

--- a/src/buttons/CopyButton/CopyButton.styles.tsx
+++ b/src/buttons/CopyButton/CopyButton.styles.tsx
@@ -1,0 +1,10 @@
+import styled, { css } from 'styled-components/native'
+import { Text } from '../../texts'
+import { StyledTextProps } from './CopyButton.Types'
+
+export const StyledText = styled(Text)<StyledTextProps>`
+  ${({ theme, disabled }: StyledTextProps) => css`
+    color: ${disabled ? theme.colors.grey2 : theme.colors.primary};
+    font-size: ${theme.size.xxs};
+  `}
+`

--- a/src/buttons/CopyButton/CopyButton.tsx
+++ b/src/buttons/CopyButton/CopyButton.tsx
@@ -1,0 +1,34 @@
+import Clipboard from '@react-native-clipboard/clipboard'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { TouchableOpacity } from 'react-native'
+import Toast from 'react-native-toast-message'
+import { CopyButtonProps } from './CopyButton.Types'
+import { StyledText } from './CopyButton.styles'
+
+const CopyButton = ({ value, copyable }: CopyButtonProps) => {
+  const { t } = useTranslation()
+
+  const handleCopy = () => {
+    Clipboard.setString(value)
+    Toast.show({
+      type: 'info',
+      text1: t('toastText.copy_Link'),
+      props: {
+        closable: true,
+      },
+    })
+  }
+
+  if (!copyable) {
+    return null
+  }
+
+  return (
+    <TouchableOpacity onPress={handleCopy} disabled={!value.length}>
+      <StyledText disabled={!value.length}>{t('copy_text_area')}</StyledText>
+    </TouchableOpacity>
+  )
+}
+
+export default CopyButton

--- a/src/buttons/index.ts
+++ b/src/buttons/index.ts
@@ -1,2 +1,3 @@
 export { default as Button } from './Button/Button'
 export { default as IconButton } from './IconButton/IconButton'
+export { default as CopyButton } from './CopyButton/CopyButton'

--- a/utils/Translations/resources/en.js
+++ b/utils/Translations/resources/en.js
@@ -1,3 +1,6 @@
 export default {
-  hello_world: 'Hello World !',
+  copy_text_area: 'Copy',
+  toastText: {
+    copy_Link: 'Copied!',
+  },
 }

--- a/utils/Translations/resources/es.js
+++ b/utils/Translations/resources/es.js
@@ -1,3 +1,6 @@
 export default {
-  hello_world: 'Hola Mundo !',
+  copy_text_area: 'Copiar',
+  toastText: {
+    copy_Link: 'Copiado!',
+  },
 }

--- a/utils/Translations/resources/fr.js
+++ b/utils/Translations/resources/fr.js
@@ -1,3 +1,6 @@
 export default {
-  hello_world: 'Bonjour le monde !',
+  copy_text_area: 'Copier',
+  toastText: {
+    copy_Link: 'Copié !',
+  },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1360,6 +1360,11 @@
   dependencies:
     merge-options "^3.0.4"
 
+"@react-native-clipboard/clipboard@^1.11.1":
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.16.1.tgz#d92753bf3f850541f8250ad1705c787c6a246f1b"
+  integrity sha512-YdSwSS3P4IiJq5nW0iv3qpntDAzBf/xoew2zRPGJ6SJZr/Lhk4aWyR506EWl6BID+iQy7xQmzHXZYR5H4apM6g==
+
 "@react-native-community/cli-clean@15.1.3":
   version "15.1.3"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-15.1.3.tgz#cc177378d9c903737fbc1f22d7aa712a61d562be"


### PR DESCRIPTION
<!-- En-tête de la PR -->

**Ticket Jira :** [#PB-1644 Copy button](https://inprogress-agency.atlassian.net/browse/PB-1644)

---

## 🚀 Changements proposés
- Ajoute le composant CopyButton au package et aux stories

## 🛠 Comment la solution a été implémentée
- Extraction et adaptation du composant `CopyButton` depuis l'app Budly
- Légère modification de la structure du dossier `stories` pour ranger les stories par catégorie

## 🔍 Comment tester cette PR ?
- Lancer Storybook et naviguer vers la story de `CopyButton`
- Appuyer sur le bouton
- Constater que le toaster apparait pour nous informer que la valeur a bien été copiée
- Tenter de coller le contenu de notre presse papier afin de vérifier que celui-ci est bien conforme à la valeur de la props `value` passée au composant.

## 🖼️ Captures d'écran (si applicable)
![image](https://github.com/user-attachments/assets/eba1d940-f129-4a50-9831-f3c922dc608e)
