### PR TITLE
feat #PB-1692 controls text area

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -54,11 +54,3 @@ export const parameters = {
     theme: storybookTheme,
   },
 }
-
-export const argTypes = {
-  color: {
-    control: {
-      type: 'color',
-    },
-  },
-}

--- a/.storybook/stories/Buttons/Button.stories.tsx
+++ b/.storybook/stories/Buttons/Button.stories.tsx
@@ -9,6 +9,11 @@ const meta: Meta<typeof Button> = {
   argTypes: {
     icon: iconOptionsWithNull,
     afterIcon: iconOptionsWithNull,
+    color: {
+      control: {
+        type: 'color',
+      },
+    },
   },
 }
 

--- a/.storybook/stories/Buttons/IconButton.stories.tsx
+++ b/.storybook/stories/Buttons/IconButton.stories.tsx
@@ -8,6 +8,11 @@ const meta: Meta<typeof IconButton> = {
   component: IconButton,
   argTypes: {
     icon: iconOptions,
+    color: {
+      control: {
+        type: 'color',
+      },
+    },
   },
 }
 

--- a/.storybook/stories/Buttons/IconButtonBadge.stories.tsx
+++ b/.storybook/stories/Buttons/IconButtonBadge.stories.tsx
@@ -7,6 +7,11 @@ const meta: Meta<typeof IconButtonBadge> = {
   component: IconButtonBadge,
   argTypes: {
     icon: iconOptions,
+    color: {
+      control: {
+        type: 'color',
+      },
+    },
   },
 }
 

--- a/.storybook/stories/Controls/CheckBox.stories.tsx
+++ b/.storybook/stories/Controls/CheckBox.stories.tsx
@@ -5,6 +5,11 @@ const meta: Meta<typeof CheckBox> = {
   title: 'Controls/CheckBox',
   component: CheckBox,
   argTypes: {
+    color: {
+      control: {
+        type: 'color',
+      },
+    },
     borderColor: {
       control: {
         type: 'color',

--- a/.storybook/stories/Controls/Switch.stories.tsx
+++ b/.storybook/stories/Controls/Switch.stories.tsx
@@ -10,6 +10,26 @@ const meta: Meta<typeof Switch> = {
         type: 'boolean',
       },
     },
+    activeThumbColor: {
+      control: {
+        type: 'color',
+      },
+    },
+    thumbColor: {
+      control: {
+        type: 'color',
+      },
+    },
+    trackColor: {
+      control: {
+        type: 'color',
+      },
+    },
+    disabled: {
+      control: {
+        type: 'boolean',
+      },
+    },
   },
 }
 

--- a/.storybook/stories/Controls/TextArea.stories.tsx
+++ b/.storybook/stories/Controls/TextArea.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { TextArea } from '../../../src/controls'
+
+const meta: Meta<typeof TextArea> = {
+  title: 'Controls/TextArea',
+  component: TextArea,
+}
+
+export default meta
+type Story = StoryObj<typeof TextArea>
+
+export const Overview: Story = {
+  args: {
+    value: 'This is my bio.',
+    copyable: true,
+    maxLength: 100,
+  },
+}

--- a/.storybook/stories/Texts/Text.stories.tsx
+++ b/.storybook/stories/Texts/Text.stories.tsx
@@ -4,6 +4,23 @@ import { Text } from '../../../src/texts'
 const meta: Meta<typeof Text> = {
   title: 'Texts/Text',
   component: Text,
+  argTypes: {
+    regular: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    color: {
+      control: {
+        type: 'color',
+      },
+    },
+    fontSize: {
+      control: {
+        type: 'number',
+      },
+    },
+  },
 }
 
 export default meta

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "react-native-gesture-handler": "^2.14.0",
     "react-native-svg": "^13.6.0",
     "react-native-toast-message": "^2.1.5",
-    "@react-native-clipboard/clipboard": "^1.11.1"
+    "@react-native-clipboard/clipboard": "^1.11.1",
+    "@gorhom/bottom-sheet": "^4.5.1"
   },
   "devDependencies": {
     "react-native-select-dropdown": "^4.0.1",
@@ -93,7 +94,8 @@
     "styled-components": "^6.1.14",
     "typescript": "^5.7.2",
     "webpack": "^5.97.1",
-    "@react-native-clipboard/clipboard": "^1.11.1"
+    "@react-native-clipboard/clipboard": "^1.11.1",
+    "@gorhom/bottom-sheet": "^4.5.1"
   },
   "scripts": {
     "build": "rimraf dist && tsc",

--- a/src/buttons/Button/Button.types.tsx
+++ b/src/buttons/Button/Button.types.tsx
@@ -1,6 +1,7 @@
-import { ColorValue, TouchableOpacityProps } from 'react-native'
+import { TouchableOpacityProps } from 'react-native'
 import { Theme } from '../../types/Theme'
 import { IconComponent } from '../../types/Icon'
+import { Color } from '../../types/Color'
 
 export type ButtonVariant = 'primary' | 'secondary'
 
@@ -32,12 +33,12 @@ export interface ButtonProps extends TouchableOpacityProps {
   /** Color of the button
    * @default theme.colors.primary
    */
-  color: ColorValue | null
+  color: Color | null
 }
 
 export interface StyledButtonProps {
   variant: ButtonVariant
-  color: ColorValue
+  color: Color
   isDarkMode: boolean
   disabled: boolean
   theme: Theme
@@ -45,7 +46,7 @@ export interface StyledButtonProps {
 
 export interface StyledTextProps {
   variant: ButtonVariant
-  color: ColorValue
+  color: Color
   isDarkMode: boolean
   theme: Theme
 }

--- a/src/buttons/IconButton/IconButton.types.tsx
+++ b/src/buttons/IconButton/IconButton.types.tsx
@@ -1,6 +1,7 @@
-import { ColorValue, TouchableOpacityProps } from 'react-native'
+import { TouchableOpacityProps } from 'react-native'
 import { Theme } from '../../../src/types/Theme'
 import { IconComponent } from '../../types/Icon'
+import { Color } from '../../types/Color'
 /**
  * Button with icon
  * @extends {TouchableOpacityProps}
@@ -9,10 +10,10 @@ export interface IconButtonProps extends TouchableOpacityProps {
   /**The icon to display in the button */
   icon: IconComponent
   /**Color of the button */
-  color: ColorValue
+  color: Color
 }
 
 export interface StyledButtonProps {
-  color: ColorValue
+  color: Color
   theme: Theme
 }

--- a/src/controls/CheckBox/CheckBox.types.tsx
+++ b/src/controls/CheckBox/CheckBox.types.tsx
@@ -1,5 +1,6 @@
-import { ColorValue, TouchableOpacityProps } from 'react-native'
+import { TouchableOpacityProps } from 'react-native'
 import { Theme } from '../../types/Theme'
+import { Color } from '../../types/Color'
 
 /**
  * Checkbox component
@@ -10,16 +11,16 @@ export interface CheckBoxProps extends TouchableOpacityProps {
   /** Current state of the checkbox */
   value: boolean
   /** Color of the checkbox icon */
-  color: ColorValue | null
+  color: Color | null
   /** Color of the checkbox border */
-  borderColor: ColorValue | null
+  borderColor: Color | null
   /** Background color when checkbox is not checked */
-  notCheckedBackgroundColor: ColorValue | null
+  notCheckedBackgroundColor: Color | null
 }
 
 export interface StyledCheckBoxProps {
   theme: Theme
   checked: boolean
-  borderColor: ColorValue | null
-  notCheckedBackgroundColor: ColorValue | null
+  borderColor: Color | null
+  notCheckedBackgroundColor: Color | null
 }

--- a/src/controls/Switch/Switch.types.tsx
+++ b/src/controls/Switch/Switch.types.tsx
@@ -1,11 +1,12 @@
+import { Color } from '../../types/Color'
 import { Theme } from '../../types/Theme'
-import { ColorValue, SwitchProps as RNSwitchProps } from 'react-native'
+import { SwitchProps as RNSwitchProps } from 'react-native'
 
 export interface SwitchProps extends RNSwitchProps {
   /**
    * Color of the foreground switch grip when active ( used only by react-native web).
    */
-  activeThumbColor?: ColorValue
+  activeThumbColor?: Color
 }
 
 export interface StyledSwitchProps {

--- a/src/controls/TextArea/TextArea.styles.tsx
+++ b/src/controls/TextArea/TextArea.styles.tsx
@@ -1,0 +1,51 @@
+import { TextInput, View } from 'react-native'
+import styled, { css } from 'styled-components/native'
+import { Text } from '../../texts'
+import { BottomSheetTextInput } from '@gorhom/bottom-sheet'
+import { StyledComponentProps } from '../../types/StyledComponent'
+import { StyledCountProps, StyledWrapperProps } from './TextArea.types'
+
+export const StyledWrapper = styled(View)`
+  ${({ theme, bgWhite }: StyledWrapperProps) => css`
+    padding: ${theme.space.std} ${theme.space.m};
+    border: ${bgWhite ? `1px solid ${theme.colors.grey1}` : `1px solid ${theme.colors.white}`};
+    background-color: ${bgWhite ? theme.colors.white : theme.colors.grey1};
+    border-radius: ${theme.borderRadius.l};
+    min-height: ${theme.size.l2};
+    justify-content: space-between;
+  `}
+`
+
+export const StyledTextInput = styled(TextInput)`
+  ${({ theme }: StyledComponentProps) => css`
+    font-family: 'Poppins-Medium';
+    width: ${theme.size.fill};
+    padding: 0;
+    margin-bottom: ${theme.space.xs};
+    color: ${theme.colors.black};
+  `}
+`
+
+export const StyledBottomSheetTextInput = styled(BottomSheetTextInput)`
+  ${({ theme }: StyledComponentProps) => css`
+    font-family: 'Poppins-Medium';
+    width: ${theme.size.fill};
+    padding: 0;
+    margin-bottom: ${theme.space.xs};
+    color: ${theme.colors.black};
+  `}
+`
+export const StyledFooter = styled(View)`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`
+
+export const StyledCount = styled(Text)`
+  ${({ theme, copyable }: StyledCountProps) => css`
+    text-align: ${copyable ? 'left' : 'right'};
+    width: ${copyable ? 'auto' : theme.size.fill};
+    color: ${theme.colors.grey2};
+    font-size: ${theme.size.xxs};
+  `}
+`

--- a/src/controls/TextArea/TextArea.tsx
+++ b/src/controls/TextArea/TextArea.tsx
@@ -1,0 +1,54 @@
+import React, { memo, useMemo } from 'react'
+import {
+  StyledBottomSheetTextInput,
+  StyledCount,
+  StyledFooter,
+  StyledTextInput,
+  StyledWrapper,
+} from './TextArea.styles'
+import { useSelector } from 'react-redux'
+import { StoreTheme } from '../../../utils/Store/Theme/Theme.types'
+import { CopyButton } from '../../buttons'
+import { TextAreaProps } from './TextArea.types'
+
+const TextArea = ({
+  value,
+  inputRef = null,
+  insideModal = false,
+  copyable = false,
+  bgWhite = false,
+  maxLength = 0,
+  ...props
+}: TextAreaProps) => {
+  const Input = useMemo(() => {
+    if (insideModal) {
+      return StyledBottomSheetTextInput
+    }
+    return StyledTextInput
+  }, [insideModal])
+  const { theme } = useSelector((state: StoreTheme) => state.theme)
+
+  return (
+    <StyledWrapper bgWhite={bgWhite}>
+      <Input
+        ref={inputRef}
+        placeholderTextColor={theme.colors.grey2}
+        selectionColor={theme.colors.black}
+        scrollEnabled={false}
+        multiline
+        defaultValue={value}
+        {...props}
+      />
+      <StyledFooter>
+        {maxLength && (
+          <StyledCount copyable={copyable}>
+            {value.length}/{maxLength}
+          </StyledCount>
+        )}
+        <CopyButton copyable={copyable} value={value} />
+      </StyledFooter>
+    </StyledWrapper>
+  )
+}
+
+export default TextArea

--- a/src/controls/TextArea/TextArea.types.tsx
+++ b/src/controls/TextArea/TextArea.types.tsx
@@ -1,0 +1,45 @@
+import { BottomSheetTextInputProps } from '@gorhom/bottom-sheet/lib/typescript/components/bottomSheetTextInput'
+import { TextInputProps } from 'react-native'
+import { StyledComponentProps } from '../../types/StyledComponent'
+
+export interface TextAreaProps {
+  /**
+   * Text to display in the text area
+   */
+  value: string
+  /**
+   * Reference to the input component
+   * @default null
+   */
+  inputRef: React.RefObject<TextInputProps> | React.RefObject<BottomSheetTextInputProps> | null
+  /**
+   * Whether the text area is inside a modal
+   * @default false
+   */
+  insideModal: boolean
+  /**
+   * Whether the text area is copyable
+   * @default false
+   */
+  copyable: boolean
+  /**
+   * Whether the text area has a white background
+   * If false, the text area will have a grey background
+   * @default false
+   */
+  bgWhite: boolean
+  /**
+   * Maximum length of the text area
+   * If set to 0, the text area will not show the maximum length
+   * @default 0
+   */
+  maxLength: number
+}
+
+export interface StyledWrapperProps extends StyledComponentProps {
+  bgWhite: boolean
+}
+
+export interface StyledCountProps extends StyledComponentProps {
+  copyable: boolean
+}

--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -1,3 +1,4 @@
 export { default as CheckBox } from './CheckBox/CheckBox'
 export { default as Switch } from './Switch/Switch'
 export { default as IconSwitch } from './IconSwitch/IconSwitch'
+export { default as TextArea } from './TextArea/TextArea'

--- a/src/texts/Text/Text.types.tsx
+++ b/src/texts/Text/Text.types.tsx
@@ -1,5 +1,6 @@
-import { ColorValue, TextProps as RNTextProps } from 'react-native'
+import { TextProps as RNTextProps } from 'react-native'
 import { Theme } from '../../../src/types/Theme'
+import { Color } from '../../types/Color'
 
 /**
  * Custom text component
@@ -13,7 +14,7 @@ export interface TextProps extends RNTextProps {
   /** Color of the text if not defined, use theme.colors.black
    * @default null
    */
-  color?: ColorValue | null
+  color?: Color | null
   /** Size of the text
    * @default 14
    */
@@ -27,6 +28,6 @@ export interface TextProps extends RNTextProps {
 export interface StyledTextProps {
   theme: Theme
   regular: boolean
-  color: ColorValue | null
+  color: Color | null
   fontSize: number | null
 }

--- a/src/types/Color.ts
+++ b/src/types/Color.ts
@@ -1,0 +1,5 @@
+type RGB = `rgb(${number}, ${number}, ${number})`
+type RGBA = `rgba(${number}, ${number}, ${number}, ${number})`
+type HEX = `#${string}`
+
+export type Color = RGB | RGBA | HEX

--- a/src/types/Theme.ts
+++ b/src/types/Theme.ts
@@ -1,19 +1,19 @@
-import { ColorValue } from 'react-native'
+import { Color } from './Color'
 
 export type Colors = {
-  primary: ColorValue
-  secondary: ColorValue
-  tertiary: ColorValue
-  white: ColorValue
-  black: ColorValue
-  grey1: ColorValue
-  grey2: ColorValue
-  grey3: ColorValue
-  red: ColorValue
-  green: ColorValue
-  warning: ColorValue
-  info: ColorValue
-  success: ColorValue
+  primary: Color
+  secondary: Color
+  tertiary: Color
+  white: Color
+  black: Color
+  grey1: Color
+  grey2: Color
+  grey3: Color
+  red: Color
+  green: Color
+  warning: Color
+  info: Color
+  success: Color
 }
 
 export type FontSize = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1226,6 +1226,21 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz#34aa0b52d0fbb1a654b596acfa595f0c7b77a77b"
   integrity sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==
 
+"@gorhom/bottom-sheet@^4.5.1":
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/@gorhom/bottom-sheet/-/bottom-sheet-4.6.4.tgz#387d0f0f21e3470eb8575498cb81ce96f5108e79"
+  integrity sha512-0itLMblLBvepE065w3a60S030c2rNUsGshPC7wbWDm31VyqoaU2xjzh/ojH62YIJOcobBr5QoC30IxBBKDGovQ==
+  dependencies:
+    "@gorhom/portal" "1.0.14"
+    invariant "^2.2.4"
+
+"@gorhom/portal@1.0.14":
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/@gorhom/portal/-/portal-1.0.14.tgz#1953edb76aaba80fb24021dc774550194a18e111"
+  integrity sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==
+  dependencies:
+    nanoid "^3.3.1"
+
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.3.0.tgz#8368869dcb735be2e7f5cb7647de78e167a251fb"
@@ -5668,7 +5683,7 @@ ms@2.1.3, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.7:
+nanoid@^3.3.1, nanoid@^3.3.7:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
   integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==


### PR DESCRIPTION
**Ticket Jira :** [#PB-1692 controls text area](https://inprogress-agency.atlassian.net/browse/PB-1692)

---

## 🚀 Changements proposés
- Ajout du composant `TextArea`

## 🛠 Comment la solution a été implémentée
- Extraction du composant depuis l'app `Budly`
- J'ai remis le type `Color` car c'etait finalement pas pertinent de le remplacer par `ColorValue`
- J'ai enlevé `color` des `argTypes` dans `preview.tsx` car cela l'ajoutais à toutes les stories même si cela n'était pas nescessaire ce que je n'avais pas compris. J'ai modifié les `argTypes` dans toutes les stories pour s'adapter à ça.

## 🖼️ Captures d'écran (si applicable)
![image](https://github.com/user-attachments/assets/bcaaf805-c502-42e4-ba4c-c42585c712c7)
