### PR TITLE
fix #PB-1694 gerer font poppins

### DIFF
--- a/src/texts/Text/Text.styles.tsx
+++ b/src/texts/Text/Text.styles.tsx
@@ -1,10 +1,12 @@
-import { Text } from 'react-native'
+import { Platform, Text } from 'react-native'
 import styled, { css } from 'styled-components/native'
 import { StyledTextProps } from './Text.types'
 
 export const StyledText = styled(Text)<StyledTextProps>`
   ${({ theme, color, regular, fontSize }: StyledTextProps) => css`
-    font-family: ${regular ? 'Poppins-Regular' : 'Poppins-Medium'};
+    ${Platform.OS === 'web'
+      ? `font-weight: ${regular ? '400' : '600'};`
+      : `font-family: ${regular ? 'Poppins-Regular' : 'Poppins-SemiBold'};`}
     color: ${color || theme.colors.black};
     font-size: ${fontSize}px;
   `}

--- a/src/texts/Text/Text.tsx
+++ b/src/texts/Text/Text.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { TextProps } from './Text.types'
 import { StyledText } from './Text.styles'
 
-
 const Text = ({ regular = false, color = null, fontSize = 14, children, ...props }: TextProps) => {
   return (
     <StyledText regular={regular} color={color} fontSize={fontSize} {...props}>


### PR DESCRIPTION
**Ticket Jira :** [#PB-1694 gerer font poppins](https://inprogress-agency.atlassian.net/browse/PB-1694)

---

## 🚀 Changements proposés
- Répare l'utilisation de la font Poppins dans le composant `Text` , `TextInput` et `TextArea`

## 🛠 Comment la solution a été implémentée
- Lorsqu'on veut utiliser la font Poppins en Regular ou Medium l'approche est différente en fonction de si nous sommes sur le web ou sur mobile. On utilise `Platform` pour détecter la plateforme et en fonction de ça, soit on change la `font-family` si on est sur mobile, sinon on change la `font-weight` si on est sur le web.

## 🔍 Comment tester cette PR ?
- Naviguer vers les composants modifiés et observer que la font utilisée est bien la bonne
- Dans le composant `Text`, faire varier la props `regular` et observer le changement.

## 🖼️ Captures d'écran (si applicable)
![image](https://github.com/user-attachments/assets/7df94f86-7c3e-4245-9be2-df80ac23b293)
