### PR TITLE
feat #PB-1729 texts stroke text

### DIFF
--- a/.storybook/stories/Texts/StrokeText.stories.tsx
+++ b/.storybook/stories/Texts/StrokeText.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { generateParameters } from '../../../utils/generateMeta/generateParameters'
+import { generateArgTypes } from '../../../utils/generateMeta/generateArgTypes'
+import { StrokeText } from '../../../src/texts'
+
+const meta: Meta<typeof StrokeText> = {
+  title: 'Texts/StrokeText',
+  component: StrokeText,
+  parameters: generateParameters(StrokeText),
+  argTypes: generateArgTypes(StrokeText),
+}
+
+export default meta
+
+export const Overview: StoryObj<typeof StrokeText> = {
+  args: { children: 'Example', fontSize: 32 },
+}

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = ({ config }) => {
       ...config.resolve.alias,
       'react-native$': 'react-native-web',
       'react-native-color-matrix-image-filters': 'react-native-web',
+      '@charmy.tech/react-native-stroke-text': 'react-native-web',
       'react/jsx-runtime': require.resolve('react/jsx-runtime'),
       'react-native-linear-gradient': 'react-native-web-linear-gradient',
     },

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "react-native-svg": "^13.6.0",
     "react-native-toast-message": "^2.1.5",
     "react-redux": "^9.2.0",
-    "styled-components": "^6.1.14"
+    "styled-components": "^6.1.14",
+    "@charmy.tech/react-native-stroke-text": "^1.2.2"
   },
   "devDependencies": {
     "@babel/core": "7.26.0",
@@ -175,7 +176,7 @@
     "storybook": "^8.4.7",
     "styled-components": "^6.1.14",
     "typescript": "^5.7.2",
-    "webpack": "^5.97.1"
+    "@charmy.tech/react-native-stroke-text": "^1.2.2"
   },
   "scripts": {
     "build": "rimraf dist && tsc",

--- a/src/texts/StrokeText/StrokeText.styles.tsx
+++ b/src/texts/StrokeText/StrokeText.styles.tsx
@@ -1,0 +1,13 @@
+import styled, { css } from 'styled-components/native'
+import { StyledWebStrokeTextProps } from './StrokeText.types'
+import Text from '../Text/Text'
+
+export const StyledWebStrokeText = styled(Text)<StyledWebStrokeTextProps>`
+  ${({ color, strokeColor, fontSize, strokeWidth }: StyledWebStrokeTextProps) => css`
+    font-size: ${fontSize}px;
+    font-weight: 800;
+    -webkit-text-fill-color: ${color};
+    -webkit-text-stroke: ${strokeWidth}px;
+    -webkit-text-stroke-color: ${strokeColor};
+  `}
+`

--- a/src/texts/StrokeText/StrokeText.tsx
+++ b/src/texts/StrokeText/StrokeText.tsx
@@ -1,0 +1,51 @@
+import { StrokeText as RNStrokeText } from '@charmy.tech/react-native-stroke-text'
+import React from 'react'
+import { useSelector } from 'react-redux'
+import { RootState } from '../../types/RootState'
+import { StrokeTextProps } from './StrokeText.types'
+import { StyledWebStrokeText } from './StrokeText.styles'
+import { Platform } from 'react-native'
+
+const MAX_STROKE_WIDTH = 10
+
+const StrokeText = ({
+  fontSize,
+  color,
+  strokeColor,
+  strokeWidth,
+  fontFamily,
+  children,
+  ...props
+}: StrokeTextProps) => {
+  const { theme } = useSelector((state: RootState) => state.theme)
+  const strokeWidthByFontSize = Math.min((fontSize || 14) / 8, MAX_STROKE_WIDTH)
+
+  console.log('fonts:', theme.fonts)
+
+  if (Platform.OS === 'web') {
+    return (
+      <StyledWebStrokeText
+        color={color || theme.colors.white}
+        strokeColor={strokeColor || theme.colors.primary}
+        fontSize={fontSize || 14}
+        strokeWidth={strokeWidth || strokeWidthByFontSize}
+      >
+        {children}
+      </StyledWebStrokeText>
+    )
+  }
+
+  return (
+    <RNStrokeText
+      text={`${children}`}
+      fontSize={fontSize || 14}
+      color={color || theme.colors.white}
+      strokeColor={strokeColor || theme.colors.primary}
+      strokeWidth={strokeWidth || strokeWidthByFontSize}
+      fontFamily={fontFamily || theme.fonts.semiBold}
+      {...props}
+    />
+  )
+}
+
+export default StrokeText

--- a/src/texts/StrokeText/StrokeText.types.ts
+++ b/src/texts/StrokeText/StrokeText.types.ts
@@ -1,0 +1,41 @@
+import { Color } from '../../types/Color'
+import { StyledComponentProps } from '../../types/StyledComponent'
+
+export interface StrokeTextProps {
+  /**
+   * The size of the text
+   * @default 14
+   */
+  fontSize?: number
+  /**
+   * The color of the text
+   * @default theme.colors.white
+   */
+  color?: Color
+  /**
+   * The color of the stroke
+   * @default theme.colors.primary
+   */
+  strokeColor?: Color
+  /**
+   * The width of the stroke
+   * @default fontSize / 8
+   */
+  strokeWidth?: number
+  /**
+   * The font family of the text
+   * @default 'Poppins-SemiBold'
+   */
+  fontFamily?: string
+  /**
+   * The text to be displayed
+   */
+  children: string
+}
+
+export interface StyledWebStrokeTextProps extends StyledComponentProps {
+  color: Color
+  strokeColor: Color
+  fontSize: number
+  strokeWidth: number
+}

--- a/src/texts/Text/Text.styles.tsx
+++ b/src/texts/Text/Text.styles.tsx
@@ -6,7 +6,7 @@ export const StyledText = styled.Text`
   ${({ theme, color, regular, fontSize }: StyledTextProps) => css`
     ${Platform.OS === 'web'
       ? `font-weight: ${regular ? '400' : '600'};`
-      : `font-family: ${regular ? 'Poppins-Regular' : 'Poppins-SemiBold'};`}
+      : `font-family: ${regular ? theme.fonts.regular : theme.fonts.semiBold};`}
     color: ${color || theme.colors.black};
     font-size: ${fontSize}px;
   `}

--- a/src/texts/index.ts
+++ b/src/texts/index.ts
@@ -1,2 +1,3 @@
 export { default as Text } from './Text/Text'
 export { default as Label } from './Label/Label'
+export { default as StrokeText } from './StrokeText/StrokeText'

--- a/src/types/Theme.ts
+++ b/src/types/Theme.ts
@@ -16,6 +16,12 @@ export interface Colors {
   success: Color
 }
 
+export interface Fonts {
+  regular: string
+  semiBold: string
+  bold: string
+}
+
 export interface FontSize {
   xxs: string
   xs: string
@@ -89,6 +95,7 @@ export interface Layout {
 
 export interface Theme {
   colors: Colors
+  fonts: Fonts
   fontSize: FontSize
   fontWeight: FontWeight
   space: Space

--- a/utils/Theme/Theme.tsx
+++ b/utils/Theme/Theme.tsx
@@ -1,4 +1,4 @@
-import { Colors, Theme } from './Theme.types'
+import { Colors, Theme } from '../../src/types/Theme'
 
 export const lightColors: Colors = {
   primary: '#5E43FF',
@@ -34,6 +34,11 @@ export const darkColors: Colors = {
 
 const theme: Theme = {
   colors: lightColors,
+  fonts: {
+    regular: 'Poppins-Regular',
+    semiBold: 'Poppins-SemiBold',
+    bold: 'Poppins-Bold',
+  },
   fontSize: {
     xxs: '10px',
     xs: '12px',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,6 +1103,11 @@
     deepmerge "^3.2.0"
     hoist-non-react-statics "^3.3.0"
 
+"@charmy.tech/react-native-stroke-text@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@charmy.tech/react-native-stroke-text/-/react-native-stroke-text-1.2.2.tgz#7d7016e01e1a195f4a039614d5a8dbf932950994"
+  integrity sha512-d3JfbtsMw1ivvFq8ZpK9cMPb6bvNBW5mOhSfwd9CqZncXxV+axMqjxgTL8SgVGr0FxFT85rhRe6Zc0hfLOQF5w==
+
 "@egjs/hammerjs@^2.0.17":
   version "2.0.17"
   resolved "https://registry.yarnpkg.com/@egjs/hammerjs/-/hammerjs-2.0.17.tgz#5dc02af75a6a06e4c2db0202cae38c9263895124"


### PR DESCRIPTION
**Ticket Jira :** [#PB-1729 texts stroke text](https://inprogress-agency.atlassian.net/browse/PB-1729)

---

## 🚀 Changements proposés
- Ajoute le composant `StrokeText`

## 🛠 Comment la solution a été implémentée
- Extraction du composant depuis l'app `Budly`
- Implémentation spécifique pour le web

## 🖼️ Captures d'écran (si applicable)
![image](https://github.com/user-attachments/assets/f38f594c-01c3-42de-9d86-24c9f982ebb4)
