### PR TITLE
#feat:PB-1731-navigation-sub-tabs

### DIFF
--- a/.storybook/stories/Navigation/SubTabs.stories.tsx
+++ b/.storybook/stories/Navigation/SubTabs.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { generateParameters } from '../../../utils/generateMeta/generateParameters'
+import { generateArgTypes } from '../../../utils/generateMeta/generateArgTypes'
+import { Subtabs } from '../../../src/navigation'
+import { Text } from 'react-native'
+import { LineHome } from '../../../src/icons'
+
+const meta: Meta<typeof Subtabs> = {
+  title: 'Navigation/SubTabs',
+  component: Subtabs,
+  argTypes: generateArgTypes(Subtabs),
+  parameters: generateParameters(Subtabs),
+}
+
+export default meta
+
+export const Overview: StoryObj<typeof Subtabs> = {
+  args: {
+    tabs: [
+      { name: 'tab1', label: 'Tab 1', icon: LineHome}, 
+      { name: 'tab2', label: 'Tab 2', icon: LineHome},
+      { name: 'tab3', label: 'Tab 3', icon: LineHome},
+    ],
+    selectedTab: { name: 'tab1', label: 'Tab 1', }, 
+    setSelectedTab: (tab) => console.log('Tab selected:', tab), 
+    children: "Label", 
+  },
+}

--- a/.storybook/stories/Navigation/SubTabs.stories.tsx
+++ b/.storybook/stories/Navigation/SubTabs.stories.tsx
@@ -1,9 +1,11 @@
+import React from 'react'
 import type { Meta, StoryObj } from '@storybook/react'
 import { generateParameters } from '../../../utils/generateMeta/generateParameters'
 import { generateArgTypes } from '../../../utils/generateMeta/generateArgTypes'
 import { Subtabs } from '../../../src/navigation'
-import { Text } from 'react-native'
 import { LineHome } from '../../../src/icons'
+import { useArgs } from 'storybook/internal/preview-api'
+import { TabItem } from '../../../src/navigation/SubTabs/SubTabs.types'
 
 const meta: Meta<typeof Subtabs> = {
   title: 'Navigation/SubTabs',
@@ -24,5 +26,14 @@ export const Overview: StoryObj<typeof Subtabs> = {
     selectedTab: { name: 'tab1', label: 'Tab 1', }, 
     setSelectedTab: (tab) => console.log('Tab selected:', tab), 
     children: "Label", 
+  },
+  render: args => {
+    const [ , setArgs] = useArgs()
+    const setSelectedTab = (value: TabItem) => {
+      args.setSelectedTab(value)
+      setArgs({ selectedTab : value })
+    }
+
+    return <Subtabs {...args} setSelectedTab={setSelectedTab} />
   },
 }

--- a/.storybook/stories/Navigation/SubTabs.stories.tsx
+++ b/.storybook/stories/Navigation/SubTabs.stories.tsx
@@ -25,7 +25,6 @@ export const Overview: StoryObj<typeof Subtabs> = {
     ],
     selectedTab: { name: 'tab1', label: 'Tab 1', }, 
     setSelectedTab: (tab) => console.log('Tab selected:', tab), 
-    children: "Label", 
   },
   render: args => {
     const [ , setArgs] = useArgs()

--- a/src/navigation/SubTabs/SubTabs.styles.tsx
+++ b/src/navigation/SubTabs/SubTabs.styles.tsx
@@ -1,10 +1,9 @@
 import styled, { css } from 'styled-components/native'
 import { Text, TouchableOpacity } from 'react-native'
-import { StyledComponentProps } from '../../types/StyledComponent'
-
+import { TabButtonProps, TabTextProps } from './SubTabs.types'
 
 export const StyledTabButton = styled(TouchableOpacity)`
-  ${({ theme, last, selected }: SubTabsProps) => css`
+  ${({ theme, last, selected, disabled }: TabButtonProps) => css`
     padding: ${theme.space.xs} ${theme.space.std};
     border-radius: ${theme.borderRadius.m};
     border: 1px solid ${selected ? theme.colors.primary : theme.colors.grey1};
@@ -19,7 +18,7 @@ export const StyledTabButton = styled(TouchableOpacity)`
 `
 
 export const StyledTabText = styled(Text)`
-  ${({ theme, selected }: StyledComponentProps) => css`
+  ${({ theme, selected }: TabTextProps) => css`
     color: ${selected ? theme.colors.black : theme.colors.grey2};
     font-size: 14px;
   `}

--- a/src/navigation/SubTabs/SubTabs.styles.tsx
+++ b/src/navigation/SubTabs/SubTabs.styles.tsx
@@ -1,0 +1,26 @@
+import styled, { css } from 'styled-components/native'
+import { Text, TouchableOpacity } from 'react-native'
+import { StyledComponentProps } from '../../types/StyledComponent'
+
+
+export const StyledTabButton = styled(TouchableOpacity)`
+  ${({ theme, last, selected }: SubTabsProps) => css`
+    padding: ${theme.space.xs} ${theme.space.std};
+    border-radius: ${theme.borderRadius.m};
+    border: 1px solid ${selected ? theme.colors.primary : theme.colors.grey1};
+    margin-right: ${last ? theme.space.m : theme.space.xs};
+    min-width: 48px;
+    justify-content: center;
+    align-items: center;
+    opacity: ${props => (props.disabled ? 0.6 : 1)};
+    flex-direction: row;
+    gap: ${theme.space.xxs};
+  `}
+`
+
+export const StyledTabText = styled(Text)`
+  ${({ theme, selected }: StyledComponentProps) => css`
+    color: ${selected ? theme.colors.black : theme.colors.grey2};
+    font-size: 14px;
+  `}
+`

--- a/src/navigation/SubTabs/SubTabs.styles.tsx
+++ b/src/navigation/SubTabs/SubTabs.styles.tsx
@@ -11,11 +11,12 @@ export const StyledTabButton = styled(TouchableOpacity)`
     min-width: 48px;
     justify-content: center;
     align-items: center;
-    opacity: ${props => (props.disabled ? 0.6 : 1)};
+    opacity: ${disabled ? 0.6 : 1}; 
     flex-direction: row;
     gap: ${theme.space.xxs};
   `}
 `
+
 
 export const StyledTabText = styled(Text)`
   ${({ theme, selected }: TabTextProps) => css`

--- a/src/navigation/SubTabs/SubTabs.styles.tsx
+++ b/src/navigation/SubTabs/SubTabs.styles.tsx
@@ -1,8 +1,15 @@
 import styled, { css } from 'styled-components/native'
-import { Text, TouchableOpacity } from 'react-native'
+import { StyleSheet, Text } from 'react-native'
 import { TabButtonProps, TabTextProps } from './SubTabs.types'
 
-export const StyledTabButton = styled(TouchableOpacity)`
+export const Scrollview = StyleSheet.create({
+  scrollView: {
+    paddingBottom: 16,
+    flexDirection: 'row',
+  },
+});
+
+export const StyledTabButton = styled.TouchableOpacity`
   ${({ theme, last, selected, disabled }: TabButtonProps) => css`
     padding: ${theme.space.xs} ${theme.space.std};
     border-radius: ${theme.borderRadius.m};

--- a/src/navigation/SubTabs/SubTabs.tsx
+++ b/src/navigation/SubTabs/SubTabs.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 
 import { StyledTabButton, StyledTabText } from './SubTabs.styles'
 import { TabItem, SubTabsProps } from './SubTabs.types'
-import { ScrollView } from 'react-native-gesture-handler'
+import { GradientScrollView } from '../../layout'
+
 
 const Subtabs: React.FC<SubTabsProps> = ({
   tabs,
@@ -13,7 +14,7 @@ const Subtabs: React.FC<SubTabsProps> = ({
   if (!tabs) return null
 
   return (
-    <ScrollView horizontal fade className="pb-4 flex flex-row">
+    <GradientScrollView horizontal fade style={{ paddingBottom: 16, flexDirection: 'row' }}>
       {tabs.map((tab: TabItem, index: number) => {
         const isSelected = selectedTab?.name === tab.name
 
@@ -30,7 +31,7 @@ const Subtabs: React.FC<SubTabsProps> = ({
         )
       })}
       {children}
-    </ScrollView>
+    </GradientScrollView>
   )
 }
 

--- a/src/navigation/SubTabs/SubTabs.tsx
+++ b/src/navigation/SubTabs/SubTabs.tsx
@@ -1,20 +1,22 @@
 import React from 'react'
 
-import { StyledTabButton, StyledTabText } from './SubTabs.styles'
+import { Scrollview, StyledTabButton, StyledTabText } from './SubTabs.styles'
 import { TabItem, SubTabsProps } from './SubTabs.types'
 import { GradientScrollView } from '../../layout'
 
 
-const Subtabs: React.FC<SubTabsProps> = ({
+const Subtabs = ({
   tabs,
   selectedTab,
   setSelectedTab,
   children,
-}) => {
-  if (!tabs) return null
+} : SubTabsProps) => {
+  if (!tabs) {
+    return null
+  }
 
   return (
-    <GradientScrollView horizontal fade style={{ paddingBottom: 16, flexDirection: 'row' }}>
+    <GradientScrollView horizontal fade  style={Scrollview.scrollView}>
       {tabs.map((tab: TabItem, index: number) => {
         const isSelected = selectedTab?.name === tab.name
 

--- a/src/navigation/SubTabs/SubTabs.tsx
+++ b/src/navigation/SubTabs/SubTabs.tsx
@@ -1,0 +1,37 @@
+// SubTabs.tsx
+import React from 'react'
+import ScrollView from 'react-native'
+import { StyledTabButton, StyledTabText } from './SubTabs.styles'
+import { TabItem, SubTabsProps } from './SubTabs.types'
+
+const Subtabs: React.FC<SubTabsProps> = ({
+  tabs,
+  selectedTab,
+  setSelectedTab,
+  children,
+}) => {
+  if (!tabs) return null
+
+  return (
+    <ScrollView horizontal fade className="pb-4 flex flex-row">
+      {tabs.map((tab: TabItem, index: number) => {
+        const isSelected = selectedTab?.name === tab.name
+
+        return (
+          <StyledTabButton
+            key={tab.name}
+            selected={isSelected}
+            onPress={() => setSelectedTab(tab)}
+            last={index === tabs.length - 1}
+          >
+            {tab.icon && <tab.icon size={16} />}
+            <StyledTabText selected={isSelected}>{tab.label}</StyledTabText>
+          </StyledTabButton>
+        )
+      })}
+      {children}
+    </ScrollView>
+  )
+}
+
+export default Subtabs

--- a/src/navigation/SubTabs/SubTabs.tsx
+++ b/src/navigation/SubTabs/SubTabs.tsx
@@ -1,8 +1,8 @@
-// SubTabs.tsx
 import React from 'react'
-import ScrollView from 'react-native'
+
 import { StyledTabButton, StyledTabText } from './SubTabs.styles'
 import { TabItem, SubTabsProps } from './SubTabs.types'
+import { ScrollView } from 'react-native-gesture-handler'
 
 const Subtabs: React.FC<SubTabsProps> = ({
   tabs,

--- a/src/navigation/SubTabs/SubTabs.types.tsx
+++ b/src/navigation/SubTabs/SubTabs.types.tsx
@@ -13,3 +13,14 @@ export interface SubTabsProps extends StyledComponentProps {
   setSelectedTab: (tab: TabItem) => void
   children?: ReactNode
 }
+
+export interface TabButtonProps extends StyledComponentProps {
+  selected: boolean
+  last: boolean
+  disabled?: boolean
+}
+
+export interface TabTextProps extends StyledComponentProps{
+  selected: boolean
+}
+

--- a/src/navigation/SubTabs/SubTabs.types.tsx
+++ b/src/navigation/SubTabs/SubTabs.types.tsx
@@ -1,10 +1,12 @@
 import { ReactNode } from 'react'
 import { StyledComponentProps } from '../../types/StyledComponent'
+import { IconComponent } from '../../types/Icon'
 
 export interface TabItem {
   name: string
   label: string
-  icon?: React.FC<{ size: number }>
+  icon?: IconComponent 
+
 }
 
 export interface SubTabsProps extends StyledComponentProps {

--- a/src/navigation/SubTabs/SubTabs.types.tsx
+++ b/src/navigation/SubTabs/SubTabs.types.tsx
@@ -12,6 +12,7 @@ export interface SubTabsProps extends StyledComponentProps {
   selectedTab: TabItem
   setSelectedTab: (tab: TabItem) => void
   children?: ReactNode
+  
 }
 
 export interface TabButtonProps extends StyledComponentProps {

--- a/src/navigation/SubTabs/SubTabs.types.tsx
+++ b/src/navigation/SubTabs/SubTabs.types.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react'
+import { StyledComponentProps } from '../../types/StyledComponent'
+
+export interface TabItem {
+  name: string
+  label: string
+  icon?: React.FC<{ size: number }>
+}
+
+export interface SubTabsProps extends StyledComponentProps {
+  tabs: TabItem[]
+  selectedTab: TabItem
+  setSelectedTab: (tab: TabItem) => void
+  children?: ReactNode
+}

--- a/src/navigation/index.ts
+++ b/src/navigation/index.ts
@@ -3,3 +3,4 @@ export { default as AuthTopNavigationBar } from './AuthTopNavigationBar/AuthTopN
 export { default as TabBarButton } from './TabBarButton/TabBarButton'
 export { default as TabBar } from './TabBar/TabBar'
 export { default as TabNavigator } from './TabNavigator/TabNavigator'
+export { default as Subtabs } from './SubTabs/SubTabs'


### PR DESCRIPTION
**Ticket Jira :** [PB-1731-navigation-sub-tabs](https://inprogress-agency.atlassian.net/browse/PB-1723?atlOrigin=eyJpIjoiYjdlNjBkYWNkYWRmNDk2MTllY2Q1MmViODNhMWM3OTQiLCJwIjoiaiJ9)

## 🚀 Changements proposés

- Ajout le composant `SubTabs`

## 🛠 Comment la solution a été implémentée

- Extraction du composant depuis l'app `Budly`

## 🖼️ Captures d'écran (si applicable)

[![image](https://github.com/user-attachments/assets/9d3384c0-3369-43a9-b75d-f8a7809346e5)](https://media.discordapp.net/attachments/1238538788804886670/1346098632964964373/image.png?ex=67c6f38b&is=67c5a20b&hm=591c1ab18cc1731941ffeef4bdf1f3445e066dbbb563097f4b61cf62bf8ae976&=&format=webp&quality=lossless&width=1430&height=804)
